### PR TITLE
[MOD-2400] Android: Feature for getting Android Advertising ID (AAID)

### DIFF
--- a/android/documentation/changelog.md
+++ b/android/documentation/changelog.md
@@ -1,5 +1,8 @@
 # Change Log
 <pre>
+
+v4.0.1 Expose getId() and isAdTrackingLimited() from AdvertisingIdClient.Info.
+
 v3.0.1  Update Google Play Services to v9.6.1 (revison 33) [TIMOB-23860]
 
 v2.1.6  Strip Google Play Services jar to reduce method count [TIMOB-18082]

--- a/android/documentation/index.md
+++ b/android/documentation/index.md
@@ -18,7 +18,7 @@ started with using this module in your application.
 Add this to the &lt;android /&gt; node in tiapp.xml: 
 
 	<android>
-	    <tool-api-level>14</tool-api-level>
+		<tool-api-level>14</tool-api-level>
 	</android>
 
 ## Accessing the Admob Module
@@ -51,20 +51,20 @@ parameters[object]: a dictionary object of properties.
 #### Example:
 
 	var adMobView = Admob.createView({
-	    publisherId: "<<YOUR PUBLISHER ID HERE>>",
-	    testing:false, // default is false
-	    top: 0, //optional
-	    left: 0, // optional
-	    right: 0, // optional
-	    bottom: 0 // optional
-	    adBackgroundColor:"FF8800", // optional
-	    backgroundColorTop: "738000", //optional - Gradient background color at top
-	    borderColor: "#000000", // optional - Border color
-	    textColor: "#000000", // optional - Text color
-	    urlColor: "#00FF00", // optional - URL color
-	    linkColor: "#0000FF" //optional -  Link text color
-	    primaryTextColor: "blue", // deprecated -- now maps to textColor
-	    secondaryTextColor: "green" // deprecated -- now maps to linkColor
+		publisherId: "<<YOUR PUBLISHER ID HERE>>",
+		testing:false, // default is false
+		top: 0, //optional
+		left: 0, // optional
+		right: 0, // optional
+		bottom: 0 // optional
+		adBackgroundColor:"FF8800", // optional
+		backgroundColorTop: "738000", //optional - Gradient background color at top
+		borderColor: "#000000", // optional - Border color
+		textColor: "#000000", // optional - Text color
+		urlColor: "#00FF00", // optional - URL color
+		linkColor: "#0000FF" //optional -  Link text color
+		primaryTextColor: "blue", // deprecated -- now maps to textColor
+		secondaryTextColor: "green" // deprecated -- now maps to linkColor
 	});
 
 ### Admob.AD_RECEIVED
@@ -74,7 +74,7 @@ returns the constant for AD_RECEIVED -- for use in an event listener
 #### Example:
 
 	adMobView.addEventListener(Admob.AD_RECEIVED,function(){
-	    alert("ad was just received");
+		alert("ad was just received");
 	});
 
 ### Admob.AD_NOT_RECEIVED
@@ -84,7 +84,7 @@ returns the constant for AD_NOT_RECEIVED -- for use in an event listener
 #### Example:
 
 	adMobView.addEventListener(Admob.AD_NOT_RECEIVED,function(){
-	    alert("ad was not received");
+		alert("ad was not received");
 	});
 
 ### AdMobView.requestAd();
@@ -102,6 +102,31 @@ Calls for a test ad if needed. This works independently from the testing flag ab
 #### Example:
 
 	adMobView.requestTestAd();
+
+### getAndroidAdID(callback)
+
+Gets the user Android Advertising ID. Since this works in a background thread in native
+Android a callback is called when the value is fetched. The callback parameter is a key/value
+pair with key `aaID` and a String value with the id.
+
+#### Example:
+
+	Admob.getAndroidAdID(function (data) {
+		Ti.API.info('AAID is ' + data.aaID);
+	});
+
+### isLimitAdTrackingEnabled(callback)
+
+Checks whether the user has opted out from ad tracking in the device's settings. Since
+this works in a background thread in native Android a callback is called when the value
+is fetched. The callback parameter is a key/value pair with key `sLimitAdTrackingEnabled`
+and a boolean value for the user's setting.
+
+#### Example:
+
+	Admob.isLimitAdTrackingEnabled(function (data) {
+		Ti.API.info('Ad tracking is limited: ' + data.isLimitAdTrackingEnabled);
+	});
 
 ## Constants
 

--- a/android/example/app.js
+++ b/android/example/app.js
@@ -73,7 +73,35 @@ adRequestBtn2.addEventListener("click",function(){
     adMobView.requestTestAd();
 });
 
+var getAAID = Ti.UI.createButton({
+    title: "Get AAID",
+    top: "40%",
+    height: "10%",
+    width: "80%"
+});
+
+var getIsAdTrackingLimited = Ti.UI.createButton({
+    title: "Is Ad tracking limited",
+    top: "55%",
+    height: "10%",
+    width: "80%"
+});
+
+getAAID.addEventListener('click', function() {
+    Admob.getAndroidAdID(function (data) {
+        Ti.API.info('AAID is ' + data.aaID);
+    });
+});
+
+getIsAdTrackingLimited.addEventListener('click', function() {
+    Admob.isLimitAdTrackingEnabled(function (data) {
+        Ti.API.info('Ad tracking is limited: ' + data.isLimitAdTrackingEnabled);
+    });
+})
+
 win.add(adMobView);
 win.add(adRequestBtn);
 win.add(adRequestBtn2);
+win.add(getAAID);
+win.add(getIsAdTrackingLimited)
 win.open();

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 4.0.0
+version: 4.0.1
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86
 description: Titanium Admob module for Android

--- a/android/src/ti/admob/AdmobModule.java
+++ b/android/src/ti/admob/AdmobModule.java
@@ -7,21 +7,36 @@
 
 package ti.admob;
 
+import android.os.AsyncTask;
+
+import java.io.IOException;
+
+import com.google.android.gms.ads.identifier.AdvertisingIdClient;
+import com.google.android.gms.common.GooglePlayServicesUtil;
+import com.google.android.gms.common.GooglePlayServicesNotAvailableException;
+import com.google.android.gms.common.GooglePlayServicesRepairableException;
+
+import org.appcelerator.kroll.KrollDict;
+import org.appcelerator.kroll.KrollFunction;
 import org.appcelerator.kroll.KrollModule;
 import org.appcelerator.kroll.annotations.Kroll;
 import org.appcelerator.kroll.common.Log;
 import org.appcelerator.titanium.TiApplication;
-import com.google.android.gms.common.GooglePlayServicesUtil;
 
 @Kroll.module(name = "Admob", id = "ti.admob")
 public class AdmobModule extends KrollModule {
 	// Standard Debugging variables
 	private static final String TAG = "AdmobModule";
 	public static String MODULE_NAME = "AndroidAdMobModule";
+
 	@Kroll.constant
 	public static final String AD_RECEIVED = "ad_received";
 	@Kroll.constant
 	public static final String AD_NOT_RECEIVED = "ad_not_received";
+
+	private final String ANDROID_ADVERTISING_ID = "aaID";
+	private final String IS_LIMIT_AD_TRACKING_ENABLED = "isLimitAdTrackingEnabled";
+
 	public static Boolean TESTING = false;
 	public static String PUBLISHER_ID;
 
@@ -36,7 +51,7 @@ public class AdmobModule extends KrollModule {
 	public static String PROPERTY_COLOR_TEXT_DEPRECATED = "primaryTextColor";
 	public static String PROPERTY_COLOR_LINK_DEPRECATED = "secondaryTextColor";
 
-	// */
+	private KrollFunction aaInfoCallback;
 
 	public AdmobModule() {
 		super();
@@ -67,6 +82,60 @@ public class AdmobModule extends KrollModule {
 	public void setTesting(Boolean testing) {
 		Log.d(TAG, "setTesting(): " + testing);
 		TESTING = testing;
+	}
+
+	@Kroll.method
+	public void isLimitAdTrackingEnabled(KrollFunction callback) {
+		if (callback != null) {
+			this.aaInfoCallback = callback;
+			new getAndroidAdvertisingIDInfo().execute(IS_LIMIT_AD_TRACKING_ENABLED);
+		}
+	}
+
+	@Kroll.method
+	public void getAndroidAdID(KrollFunction callback) {
+		if (callback != null) {
+			this.aaInfoCallback = callback;
+			new getAndroidAdvertisingIDInfo().execute(ANDROID_ADVERTISING_ID);
+		}
+	}
+
+	private void invokeAIDCleintInfoCallback(AdvertisingIdClient.Info aaClientIDInfo, String responseKey) {
+		KrollDict callbackDictionary = new KrollDict();
+		Object responseValue = null;
+		switch (responseKey) {
+			case ANDROID_ADVERTISING_ID:
+				responseValue = aaClientIDInfo.getId();
+				break;
+			case IS_LIMIT_AD_TRACKING_ENABLED:
+				responseValue = aaClientIDInfo.isLimitAdTrackingEnabled();
+				break;
+		}
+		callbackDictionary.put(responseKey, responseValue);
+		this.aaInfoCallback.callAsync(getKrollObject(), callbackDictionary);
+	}
+
+	private class getAndroidAdvertisingIDInfo extends AsyncTask<String, Integer, String> {
+
+		private AdvertisingIdClient.Info aaClientIDInfo = null;
+
+		@Override
+		protected String doInBackground(String... responseKey) {
+			try {
+				aaClientIDInfo = AdvertisingIdClient.getAdvertisingIdInfo(TiApplication.getInstance().getApplicationContext());
+				return responseKey[0];
+			} catch (IOException | GooglePlayServicesNotAvailableException | GooglePlayServicesRepairableException e) {
+				e.printStackTrace();
+				return null;
+			}
+		}
+
+		@Override
+		protected void onPostExecute(String responseKey) {
+			if (aaClientIDInfo != null) {
+				invokeAIDCleintInfoCallback(aaClientIDInfo, responseKey);
+			}
+		}
 	}
 
 }


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/MOD-2400

**Description:**
Expose getId and isLimitAdTrackingEnabled from AdvertisingIdClient.Info. Fixed indentation here and there.

**Test case:**
_app.js_
```
var win = Titanium.UI.createWindow({
  backgroundColor: "#FFFFFF"
});

// require AdMob
var Admob = require('ti.admob');

// check if google play services are available
var code = Admob.isGooglePlayServicesAvailable();
if (code != Admob.SUCCESS) {
    alert("Google Play Services is not installed/updated/available");
}

var requestAAID = Ti.UI.createButton({
    title:"Request AAID",
    top:"10%",
    height: "10%",
    width: "80%"
});

requestAAID.addEventListener("click",function(){
    Admob.getAndroidAdID(function (data) {
        Ti.API.info('AAID is ' + data.aaID);
    });
});

var isAdTrackingEnabled = Ti.UI.createButton({
    title: "Is AD tracking limited",
    top: "25%",
    height: "10%",
    width: "80%"
});

isAdTrackingEnabled.addEventListener("click",function(){
    Admob.isLimitAdTrackingEnabled(function (data) {
        Ti.API.info('Ad tracking is limited: ' + data.isLimitAdTrackingEnabled);
    });
});

win.add(requestAAID);
win.add(isAdTrackingEnabled);
win.open();
```

Note for QE:
These are set/reset in the Google Setting of the device and are not application specific.