### PR TITLE
[MOD-2470] Ti.AdMob: Add Rewarded Video event

### DIFF
--- a/android/documentation/changelog.md
+++ b/android/documentation/changelog.md
@@ -2,6 +2,8 @@
 
 <pre>
 
+v4.5.0  Added support for Rewarded Video Ads. 
+
 v4.4.0  Maintain API parity with iOS module and introduce Interstitial ads support on Android.
 
 v4.3.0  Support the Facebook Audience Network adapter

--- a/android/documentation/index.md
+++ b/android/documentation/index.md
@@ -71,6 +71,8 @@ parameters[object]: a dictionary object of properties.
 
 returns the constant for AD_RECEIVED -- for use in an event listener
 
+Warning: This constant has been deprecated since version 4.5.0
+
 #### Example:
 
 	adMobView.addEventListener(Admob.AD_RECEIVED, function () {
@@ -84,6 +86,8 @@ error code in its parameter under the key `errorCode`
 Error codes for Android can be checked here:
 https://developers.google.com/android/reference/com/google/android/gms/ads/AdRequest#ERROR_CODE_INTERNAL_ERROR
 
+Warning: This constant has been deprecated since version 4.5.0
+
 #### Example:
 
 	adMobView.addEventListener(Admob.AD_NOT_RECEIVED, function (e) {
@@ -94,6 +98,8 @@ https://developers.google.com/android/reference/com/google/android/gms/ads/AdReq
 
 returns the constant for AD_OPENED -- for use in an event listener
 
+Warning: This constant has been deprecated since version 4.5.0
+
 #### Example:
 
 	adMobView.addEventListener(Admob.AD_OPENED, function () {
@@ -102,6 +108,8 @@ returns the constant for AD_OPENED -- for use in an event listener
 
 ### `Admob.AD_CLOSED`
 
+Warning: This constant has been deprecated since version 4.5.0
+
 #### Example:
 
 	adMobView.addEventListener(Admob.AD_CLOSED, function () {
@@ -109,6 +117,8 @@ returns the constant for AD_OPENED -- for use in an event listener
 	});
 
 ### `Admob.AD_LEFT_APPLICATION`
+
+Warning: This constant has been deprecated since version 4.5.0
 
 #### Example:
 
@@ -322,6 +332,101 @@ Shows an Interstitial ad if there is one successfully loaded.
 	    Ti.API.info('Interstitial Ad left application!');
 	});
 	interstitialAd.load();
+
+
+### Rewarded Video Ads
+
+In version 4.5.0 support for Admob Rewarded Video Ads was added. This is a similar type of ad to the Interstitial with the
+addition of getting a reward after watching an ad video.
+
+Since videos are pretty heavy to load it is recommended that the Rewarded Video Ad is fully loaded before showing it to the
+user. Similar to the Interstitial ads the Reward Video Ads are using one instance of the class to load and show a single ad
+multiple times. Meaning that you can load an add, show it at a proper time for your UX and after you get the closed/rewarded
+event you can load another video through the same instance and wait for the best time to show it to the user.
+
+#### Methods
+
+##### loadAd(String adUnitId)
+
+Loads an ad with the provided adUnitId
+
+##### show()
+
+Shows the most recent ad if it was successfully loaded.
+
+#### Events
+
+##### adloaded
+
+Fired when a rewarded video ad was successfully loaded.
+
+##### adrewarded
+
+Fired when the user was rewarded for watching an ad. This event contains a
+dictionary with the properties "type" and "amount" which determine the reward.
+
+##### adfailedtoload
+
+Fired if the video reward ad was unable to load.
+
+##### adleftapplication
+
+Fired when the user has left the application, for instance to visit the Play Store.
+
+##### adclosed
+
+Fired when the user has closed the rewarded video ad.
+
+##### adopened
+
+Fired when the rewarded video ad has been opened.
+
+##### videostarted
+
+Fired when the video of the rewarded ad has begun playing.
+
+#### Example
+
+	var Admob = require('ti.admob'),
+	    win = Titanium.UI.createWindow({ layout: 'vertical'}),
+	    rewardedVideo = Admob.createRewardedVideo(),
+	    buttonLoadAd = Ti.UI.createButton({ title: 'Load Ad'}),
+	    buttonShowAd = Ti.UI.createButton({ title: 'Show Ad', enabled: false, touchEnabled: false}),
+	    buttonClaimReward = Ti.UI.createButton({ title: 'Claim Reward', enabled: false, touchEnabled: false}),
+	    reward;
+
+	buttonLoadAd.addEventListener('click', function () {
+	    rewardedVideo.loadAd('ca-app-pub-3940256099942544/5224354917');
+	})
+
+	buttonShowAd.addEventListener('click', function () {
+	    rewardedVideo.show();
+	});
+
+	buttonClaimReward.addEventListener('click', function () {
+	    alert('You have received ' + reward.amount + ' ' + reward.type);
+	    buttonClaimReward.enabled = false;
+	    buttonClaimReward.touchEnabled = false;
+	});
+
+	rewardedVideo.addEventListener('adloaded', function () {
+	    buttonShowAd.enabled = true;
+	    buttonShowAd.touchEnabled = true;
+	});
+
+	rewardedVideo.addEventListener('adrewarded', function (rewardItem) {
+	    reward = rewardItem;
+	    buttonClaimReward.enabled = true;
+	    buttonClaimReward.touchEnabled = true;
+	});
+
+	rewardedVideo.addEventListener('adclosed', function () {
+	    buttonShowAd.enabled = false;
+	    buttonShowAd.touchEnabled = false;
+	});
+
+	win.add([buttonLoadAd, buttonShowAd, buttonClaimReward]);
+	win.open();
 
 ## Author
 

--- a/android/manifest
+++ b/android/manifest
@@ -3,7 +3,7 @@
 # during compilation, packaging, distribution, etc.
 #
 
-version: 4.4.0
+version: 4.5.0
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86
 description: Titanium Admob module for Android

--- a/android/src/ti/admob/RewardedVideoProxy.java
+++ b/android/src/ti/admob/RewardedVideoProxy.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2011 by Studio Classics. All Rights Reserved.
+ * Copyright (c) 2017-present by Axway Appcelerator. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+package ti.admob;
+
+import com.google.android.gms.ads.AdRequest;
+import com.google.android.gms.ads.MobileAds;
+import com.google.android.gms.ads.reward.RewardItem;
+import com.google.android.gms.ads.reward.RewardedVideoAd;
+import com.google.android.gms.ads.reward.RewardedVideoAdListener;
+
+import org.appcelerator.kroll.KrollDict;
+import org.appcelerator.kroll.KrollProxy;
+import org.appcelerator.kroll.annotations.Kroll;
+import org.appcelerator.kroll.common.Log;
+
+@Kroll.proxy(creatableInModule = AdmobModule.class)
+public class RewardedVideoProxy extends KrollProxy implements RewardedVideoAdListener {
+
+	private final static String EVENT_ON_AD_LOADED = "adloaded";
+	private final static String EVENT_ON_AD_REWARDED = "adrewarded";
+	private final static String EVENT_ON_AD_FAILED_TO_LOAD = "adfailedtoload";
+	private final static String EVENT_ON_AD_LEFT_APPLICATION = "adleftapplication";
+	private final static String EVENT_ON_AD_CLOSED = "adclosed";
+	private final static String EVENT_ON_AD_OPENED = "adopened";
+	private final static String EVENT_ON_VIDEO_STARTED = "videostarted";
+	// The following event is not yet available in admob version 11.8
+	public final static String EVENT_ON_VIDEO_COMPLETED = "videocompleted";
+
+	private final static String TAG = "RewardedVideo";
+
+	private final static String PROPERTY_TYPE = "type";
+	private final static String PROPERTY_AMOUNT = "amount";
+
+	private RewardedVideoAd rewardedVideoAd;
+
+	public RewardedVideoProxy() {
+		this.rewardedVideoAd = MobileAds.getRewardedVideoAdInstance(getActivity());
+		this.rewardedVideoAd.setRewardedVideoAdListener(this);
+	}
+
+	@Kroll.method
+	public void loadAd(String adUnitId) {
+		this.rewardedVideoAd.loadAd(adUnitId, new AdRequest.Builder().build());
+	}
+
+	@Kroll.method
+	public void show() {
+		if (this.rewardedVideoAd.isLoaded()) {
+			this.rewardedVideoAd.show();
+		} else {
+			Log.w(TAG, "Trying to show a rewarded video ad that has not loaded.");
+		}
+	}
+
+	@Override
+	public void onRewardedVideoAdLoaded() {
+		if (this.hasListeners(EVENT_ON_AD_LOADED)) {
+			fireEvent(EVENT_ON_AD_LOADED, new KrollDict());
+		}
+	}
+
+	@Override
+	public void onRewardedVideoAdOpened() {
+		if (this.hasListeners(EVENT_ON_AD_OPENED)) {
+			fireEvent(EVENT_ON_AD_OPENED, new KrollDict());
+		}
+	}
+
+	@Override
+	public void onRewardedVideoStarted() {
+		if (this.hasListeners(EVENT_ON_VIDEO_STARTED)) {
+			fireEvent(EVENT_ON_VIDEO_STARTED, new KrollDict());
+		}
+	}
+
+	@Override
+	public void onRewardedVideoAdClosed() {
+		if (this.hasListeners(EVENT_ON_AD_CLOSED)) {
+			fireEvent(EVENT_ON_AD_CLOSED, new KrollDict());
+		}
+	}
+
+	@Override
+	public void onRewarded(RewardItem rewardItem) {
+		if (this.hasListeners(EVENT_ON_AD_REWARDED)) {
+			KrollDict rewardReceived = new KrollDict();
+			rewardReceived.put(PROPERTY_TYPE, rewardItem.getType());
+			rewardReceived.put(PROPERTY_AMOUNT, rewardItem.getAmount());
+			fireEvent(EVENT_ON_AD_REWARDED, rewardReceived);
+		}
+	}
+
+	@Override
+	public void onRewardedVideoAdLeftApplication() {
+		if (this.hasListeners(EVENT_ON_AD_LEFT_APPLICATION)) {
+			fireEvent(EVENT_ON_AD_LEFT_APPLICATION, new KrollDict());
+		}
+	}
+
+	@Override
+	public void onRewardedVideoAdFailedToLoad(int i) {
+		if (this.hasListeners(EVENT_ON_AD_FAILED_TO_LOAD)) {
+			fireEvent(EVENT_ON_AD_FAILED_TO_LOAD, new KrollDict());
+		}
+	}
+}


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/MOD-2470

**Description:**
Add support for Rewarded Video Ad in Android.
Add deprecation warnings for the events in the common listener for AdView and Interstitial ad. The target is to follow the format and style in the core Titanium SDK, meaning that they won't be accessible as constants, from the next major version.

**Sample:**
```js
var Admob = require('ti.admob'),
    win = Titanium.UI.createWindow({ layout: 'vertical'}),
    rewardedVideo = Admob.createRewardedVideo(),
    buttonLoadAd = Ti.UI.createButton({ title: 'Load Ad'}),
    buttonShowAd = Ti.UI.createButton({ title: 'Show Ad', enabled: false, touchEnabled: false}),
    buttonClaimReward = Ti.UI.createButton({ title: 'Claim Reward', enabled: false, touchEnabled: false}),
    reward;

buttonLoadAd.addEventListener('click', function () {
    rewardedVideo.loadAd('ca-app-pub-3940256099942544/5224354917');
})

buttonShowAd.addEventListener('click', function () {
    rewardedVideo.show();
});

buttonClaimReward.addEventListener('click', function () {
    alert('You have received ' + reward.amount + ' ' + reward.type);
    buttonClaimReward.enabled = false;
    buttonClaimReward.touchEnabled = false;
});

rewardedVideo.addEventListener('adloaded', function () {
    buttonShowAd.enabled = true;
    buttonShowAd.touchEnabled = true;
});

rewardedVideo.addEventListener('adrewarded', function (rewardItem) {
    reward = rewardItem;
    buttonClaimReward.enabled = true;
    buttonClaimReward.touchEnabled = true;
});

rewardedVideo.addEventListener('adclosed', function () {
    buttonShowAd.enabled = false;
    buttonShowAd.touchEnabled = false;
});

win.add([buttonLoadAd, buttonShowAd, buttonClaimReward]);
win.open();
```