### PR TITLE
[MOD-2479] Android: Interstitial Ads not working with background thread

### DIFF
--- a/android/src/ti/admob/InterstitialAdProxy.java
+++ b/android/src/ti/admob/InterstitialAdProxy.java
@@ -15,6 +15,8 @@ import org.appcelerator.kroll.KrollProxy;
 import org.appcelerator.kroll.annotations.Kroll;
 import org.appcelerator.kroll.common.Log;
 
+import org.appcelerator.titanium.TiApplication;
+
 @Kroll.proxy(creatableInModule = AdmobModule.class)
 public class InterstitialAdProxy extends KrollProxy {
 
@@ -58,12 +60,34 @@ public class InterstitialAdProxy extends KrollProxy {
 	@Kroll.method
 	public void load()
 	{
-		this.interstitialAd.loadAd(new AdRequest.Builder().build());
+		if (!TiApplication.getInstance().runOnMainThread()) {
+			getActivity().runOnUiThread(new Runnable() {
+				@Override
+				public void run() {
+					interstitialAd.loadAd(new AdRequest.Builder().build());
+				}
+			});
+		} else {
+			this.interstitialAd.loadAd(new AdRequest.Builder().build());
+		}
 	}
 
 	@Kroll.method
 	public void show()
 	{
+		if (!TiApplication.getInstance().runOnMainThread()) {
+			getActivity().runOnUiThread(new Runnable() {
+				@Override
+				public void run() {
+					showInterstitial();
+				}
+			});
+		} else {
+			showInterstitial();
+		}
+	}
+
+	private void showInterstitial() {
 		if (this.interstitialAd.isLoaded()) {
 			this.interstitialAd.show();
 		} else {


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/MOD-2479

**Description:**
Make sure to always load and show Interstitial ads from the main thread.
We can pun this together in a release with https://github.com/appcelerator-modules/ti.admob/pull/83, but if we decide to separate it I will update the version in this PR too.

**Test case:**
The sample in the module is good enough to test this. Run it with different values of `run-on-main-thread` property in the application's tiapp.xml file.