### PR TITLE
feat(android): adopt new unified cross-platform api

### DIFF
--- a/android/documentation/changelog.md
+++ b/android/documentation/changelog.md
@@ -2,7 +2,7 @@
 
 <pre>
 
-v5.0.0 Update APIs to match the Swift version of the iOS part of the module. Set Titanium 8.0.0 as minimum.
+v4.5.0 Update APIs to match the Swift version of the iOS part of the module. Set Titanium 8.0.0 as minimum.
 
 v4.4.0  Maintain API parity with iOS module and introduce Interstitial ads support on Android.
 

--- a/android/documentation/changelog.md
+++ b/android/documentation/changelog.md
@@ -2,6 +2,8 @@
 
 <pre>
 
+v5.0.0 Update APIs to match the Swift version of the iOS part of the module. Set Titanium 8.0.0 as minimum.
+
 v4.4.0  Maintain API parity with iOS module and introduce Interstitial ads support on Android.
 
 v4.3.0  Support the Facebook Audience Network adapter

--- a/android/documentation/index.md
+++ b/android/documentation/index.md
@@ -14,6 +14,19 @@ In any event, you will either need to NOT set your screen support -- or set andr
 View the [Using Titanium Modules](http://docs.appcelerator.com/titanium/latest/#!/guide/Using_Titanium_Modules) document 
 for instructions on getting started with using this module in your application.
 
+In order to use the module you would need to add the following tags in yout tiapp.xml
+
+	<android 
+	    xmlns:android="http://schemas.android.com/apk/res/android">
+	    <manifest>
+	      <application>
+	        <meta-data
+	            android:name="com.google.android.gms.ads.APPLICATION_ID"
+	            android:value="your-admob-application-id"/>
+	      </application>
+	    </manifest>
+	  </android>
+
 ## Requirements
 
 - [x] Titanium SDK 7.0.0+
@@ -32,190 +45,6 @@ The "Admob" variable is now a reference to the Module object.
 ## Doubleclick for Publishers Developer Docs
 
 <https://developers.google.com/mobile-ads-sdk/>
-
-## Functions
-
-### Number isGooglePlayServicesAvailable()
-
-Returns a number value indicating the availability of Google Play Services which are for push notifications.
-
-Possible values include `SUCCESS`, `SERVICE_MISSING`, `SERVICE_VERSION_UPDATE_REQUIRED`, `SERVICE_DISABLED`,
-and `SERVICE_INVALID`.
-
-### `createAdMobView(args)`
-
-Returns a view with an ad initialized by default.
-
-#### Arguments
-
-parameters[object]: a dictionary object of properties.
-
-#### Example:
-
-	var adMobView = Admob.createView({
-	    adUnitId: 'ENTER_YOUR_AD_UNIT_ID_HERE',
-	    testing:false, // default is false
-	    top: 0, // optional
-	    left: 0, // optional
-	    right: 0, // optional
-	    bottom: 0 // optional
-	    adBackgroundColor: '#FF8800', // optional
-	    backgroundColorTop: '#738000', // optional - Gradient background color at top
-	    borderColor: '#000000', // optional - Border color
-	    textColor: '#000000', // optional - Text color
-	    urlColor: '#00FF00', // optional - URL color
-	    linkColor: '#0000FF' // optional -  Link text color
-	});
-
-### `Admob.AD_RECEIVED`
-
-returns the constant for AD_RECEIVED -- for use in an event listener
-
-#### Example:
-
-	adMobView.addEventListener(Admob.AD_RECEIVED, function () {
-	    alert('ad was just received');
-	});
-
-### `Admob.AD_NOT_RECEIVED`
-
-returns whenever the ad was not successfully loaded. The callback contains the
-error code in its parameter under the key `errorCode`
-Error codes for Android can be checked here:
-https://developers.google.com/android/reference/com/google/android/gms/ads/AdRequest#ERROR_CODE_INTERNAL_ERROR
-
-#### Example:
-
-	adMobView.addEventListener(Admob.AD_NOT_RECEIVED, function (e) {
-	    alert('ad was not received. error code is ' + e.errorCode);
-	});
-
-### `Admob.AD_OPENED`
-
-returns the constant for AD_OPENED -- for use in an event listener
-
-#### Example:
-
-	adMobView.addEventListener(Admob.AD_OPENED, function () {
-	    alert('ad was just opened');
-	});
-
-### `Admob.AD_CLOSED`
-
-#### Example:
-
-	adMobView.addEventListener(Admob.AD_CLOSED, function () {
-	    alert('ad was just closed');
-	});
-
-### `Admob.AD_LEFT_APPLICATION`
-
-#### Example:
-
-	adMobView.addEventListener(Admob.AD_LEFT_APPLICATION, function () {
-	    alert('user just left the application through the ad');
-	});
-
-### `AdMobView.requestAd(args)`
-
-Calls for a new ad if needed. Pass optional `args` to configure extras.
-
-#### Example:
-
-```js
-adMobView.requestAd({
-    extras: {
-        'npa': '1' // Disable personalized ads (GDPR)
-    }
-});
-```
-
-### `AdMobView.requestTestAd()`
-
-Calls for a test ad if needed. This works independently from the testing flag above.
-
-#### Example:
-
-```js
-adMobView.requestTestAd();
-```
-
-### `requestConsentInfoUpdateForPublisherIdentifiers(args)`
-
-Requests consent information update for the provided publisher identifiers. All publisher
-identifiers used in the application should be specified in this call. Consent status is reset to
-unknown when the ad provider list changes.
-
-- `publisherIdentifiers` (Array<String>)
-- `callback` (Function)
-
-### `showConsentForm(args)`
-
-Shows a consent modal form. Arguments:
-
-- `shouldOfferPersonalizedAds` (Boolean)
-Indicates whether the consent form should show a personalized ad option. Defaults to `true`.
-- `shouldOfferNonPersonalizedAds` (Boolean)
-Indicates whether the consent form should show a non-personalized ad option. Defaults to `true`.
-- `shouldOfferAdFree` (Boolean)
-Indicates whether the consent form should show an ad-free app option. Defaults to `false`.
-- `callback` (Function)
-Callback to be triggered once the form completes.
-
-### `resetConsent()`
-
-Resets consent information to default state and clears ad providers.
-
-### `setTagForUnderAgeOfConsent(true|false)`
-
-Sets whether the user is tagged for under age of consent.
-
-### `isTaggedForUnderAgeOfConsent()` (Boolean)
-
-Indicates whether the user is tagged for under age of consent.
-
-## Properties
-
-### `consentStatus` (`CONSENT_STATUS_UNKNOWN`, `CONSENT_STATUS_NON_PERSONALIZED` or `CONSENT_STATUS_PERSONALIZED`)
-
-### `adProviders` (Array)
-
-Array of ad providers.
-
-### `debugGeography` (`DEBUG_GEOGRAPHY_DISABLED`, `DEBUG_GEOGRAPHY_EEA` or `DEBUG_GEOGRAPHY_NOT_EEA`)
-
-Debug geography. Used for debug devices only.
-
-### getAndroidAdId(callback)
-
-Gets the user Android Advertising ID. Since this works in a background thread in native
-Android a callback is called when the value is fetched. The callback parameter is a key/value
-pair with key `androidAdId` and a String value with the id.
-
-#### Example:
-
-	Admob.getAndroidAdId(function (data) {
-		Ti.API.info('AAID is ' + data.aaID);
-	});
-
-### isLimitAdTrackingEnabled(callback)
-
-Checks whether the user has opted out from ad tracking in the device's settings. Since
-this works in a background thread in native Android a callback is called when the value
-is fetched. The callback parameter is a key/value pair with key `isLimitAdTrackingEnabled`
-and a boolean value for the user's setting.
-
-#### Example:
-
-	Admob.isLimitAdTrackingEnabled(function (data) {
-		Ti.API.info('Ad tracking is limited: ' + data.isLimitAdTrackingEnabled);
-	});
-
-### Support the Facebook Audience Network adapter
-
-Starting in 4.3.0 you can use the included Facebook Audience Network adapter to turn on the mediation in your AdMob account.
-Here you do not have to do anything 😙. You only need to configure mediation in your AdMob and Facebook accounts by 
-following the [official guide](https://developers.google.com/admob/android/mediation/facebook).
 
 ## Constants
 
@@ -252,6 +81,214 @@ Returned by `debugGeography` if geography appears as in EEA for debug devices.
 ### Number `DEBUG_GEOGRAPHY_NOT_EEA`
 Returned by `debugGeography` if geography appears as not in EEA for debug devices.
 
+### `Admob.AD_RECEIVED`
+DEPRECATED since 5.0.0
+returns the constant for AD_RECEIVED -- for use in an event listener
+
+#### Example:
+
+	adMobView.addEventListener(Admob.AD_RECEIVED, function () {
+	    alert('ad was just received');
+	});
+
+### `Admob.AD_NOT_RECEIVED`
+DEPRECATED since 5.0.0
+returns whenever the ad was not successfully loaded. The callback contains the
+error code in its parameter under the key `errorCode`
+Error codes for Android can be checked here:
+https://developers.google.com/android/reference/com/google/android/gms/ads/AdRequest#ERROR_CODE_INTERNAL_ERROR
+
+#### Example:
+
+	adMobView.addEventListener(Admob.AD_NOT_RECEIVED, function (e) {
+	    alert('ad was not received. error code is ' + e.errorCode);
+	});
+
+### `Admob.AD_OPENED`
+DEPRECATED since 5.0.0
+returns the constant for AD_OPENED -- for use in an event listener
+
+#### Example:
+
+	adMobView.addEventListener(Admob.AD_OPENED, function () {
+	    alert('ad was just opened');
+	});
+
+### `Admob.AD_CLOSED`
+DEPRECATED since 5.0.0
+#### Example:
+
+	adMobView.addEventListener(Admob.AD_CLOSED, function () {
+	    alert('ad was just closed');
+	});
+
+### `Admob.AD_LEFT_APPLICATION`
+DEPRECATED since 5.0.0
+#### Example:
+
+	adMobView.addEventListener(Admob.AD_LEFT_APPLICATION, function () {
+	    alert('user just left the application through the ad');
+	});
+
+### Admob.AD_SIZE_BANNER
+
+### Admob.AD_SIZE_FLUID
+
+### Admob.AD_SIZE_FULL_BANNER
+
+### Admob.AD_SIZE_LARGE_BANNER
+
+### Admob.AD_SIZE_LEADERBOARD
+
+### Admob.AD_SIZE_MEDIUM_RECTANGLE
+
+### Admob.AD_SIZE_SEARCH
+
+### Admob.AD_SIZE_SMART_BANNER
+
+### Admob.AD_SIZE_WIDE_SKYSCRAPER
+
+## Functions
+
+### initialize(admobApplicationID)
+
+You need to initialize the Admob SDK by passing your AdmobAppID as a parameter to this method.
+
+### Number isGooglePlayServicesAvailable()
+
+Returns a number value indicating the availability of Google Play Services which are for push notifications.
+
+Possible values include `SUCCESS`, `SERVICE_MISSING`, `SERVICE_VERSION_UPDATE_REQUIRED`, `SERVICE_DISABLED`,
+and `SERVICE_INVALID`.
+
+### `createView(args)`
+DEPRECATED since 5.0.0
+Returns a view with an ad initialized by default.
+
+#### Arguments
+
+parameters[object]: a dictionary object of properties.
+
+#### Example:
+
+	var adMobView = Admob.createView({
+	    adUnitId: 'ENTER_YOUR_AD_UNIT_ID_HERE',
+	    testing:false, // default is false
+	    top: 0, // optional
+	    left: 0, // optional
+	    right: 0, // optional
+	    bottom: 0 // optional
+	    adBackgroundColor: '#FF8800', // optional
+	    backgroundColorTop: '#738000', // optional - Gradient background color at top
+	    borderColor: '#000000', // optional - Border color
+	    textColor: '#000000', // optional - Text color
+	    urlColor: '#00FF00', // optional - URL color
+	    linkColor: '#0000FF' // optional -  Link text color
+	});
+
+### `AdMobView.requestAd(args)`
+DEPRECATED since 5.0.0
+Calls for a new ad if needed. Pass optional `args` to configure extras.
+
+#### Example:
+
+```js
+adMobView.requestAd({
+    extras: {
+        'npa': '1' // Disable personalized ads (GDPR)
+    }
+});
+```
+
+### `AdMobView.requestTestAd()`
+DEPRECATED since 5.0.0
+Calls for a test ad if needed. This works independently from the testing flag above.
+
+#### Example:
+
+```js
+adMobView.requestTestAd();
+```
+
+### `requestConsentInfoUpdateForPublisherIdentifiers(args)`
+
+Requests consent information update for the provided publisher identifiers. All publisher
+identifiers used in the application should be specified in this call. Consent status is reset to
+unknown when the ad provider list changes.
+
+- `publisherIdentifiers` (Array<String>)
+- `callback` (Function)
+
+### `showConsentForm(args)`
+
+Shows a consent modal form. Arguments:
+
+- `shouldOfferPersonalizedAds` (Boolean)
+Indicates whether the consent form should show a personalized ad option. Defaults to `true`.
+- `shouldOfferNonPersonalizedAds` (Boolean)
+Indicates whether the consent form should show a non-personalized ad option. Defaults to `true`.
+- `shouldOfferAdFree` (Boolean)
+Indicates whether the consent form should show an ad-free app option. Defaults to `false`.
+- `callback` (Function)
+Callback to be triggered once the form completes.
+
+### `resetConsent()`
+
+Resets consent information to default state and clears ad providers.
+
+### `setTagForUnderAgeOfConsent(true|false)`
+DEPRECATED since 5.0.0
+Sets whether the user is tagged for under age of consent.
+
+### `isTaggedForUnderAgeOfConsent()` (Boolean)
+DEPRECATED since 5.0.0
+Indicates whether the user is tagged for under age of consent.
+
+## Properties
+
+### `consentStatus` (`CONSENT_STATUS_UNKNOWN`, `CONSENT_STATUS_NON_PERSONALIZED` or `CONSENT_STATUS_PERSONALIZED`)
+
+### `adProviders` (Array)
+
+Array of ad providers.
+
+### `debugGeography` (`DEBUG_GEOGRAPHY_DISABLED`, `DEBUG_GEOGRAPHY_EEA` or `DEBUG_GEOGRAPHY_NOT_EEA`)
+
+Debug geography. Used for debug devices only.
+
+### IsTaggedForUnderAgeOfConsent: Boolean
+
+### getAndroidAdId(callback)
+
+Gets the user Android Advertising ID. Since this works in a background thread in native
+Android a callback is called when the value is fetched. The callback parameter is a key/value
+pair with key `androidAdId` and a String value with the id.
+
+#### Example:
+
+	Admob.getAndroidAdId(function (data) {
+		Ti.API.info('AAID is ' + data.aaID);
+	});
+
+### isLimitAdTrackingEnabled(callback)
+
+Checks whether the user has opted out from ad tracking in the device's settings. Since
+this works in a background thread in native Android a callback is called when the value
+is fetched. The callback parameter is a key/value pair with key `isLimitAdTrackingEnabled`
+and a boolean value for the user's setting.
+
+#### Example:
+
+	Admob.isLimitAdTrackingEnabled(function (data) {
+		Ti.API.info('Ad tracking is limited: ' + data.isLimitAdTrackingEnabled);
+	});
+
+### Support the Facebook Audience Network adapter
+
+Starting in 4.3.0 you can use the included Facebook Audience Network adapter to turn on the mediation in your AdMob account.
+Here you do not have to do anything 😙. You only need to configure mediation in your AdMob and Facebook accounts by 
+following the [official guide](https://developers.google.com/admob/android/mediation/facebook).
+
 ## Module History
 
 View the [change log](changelog.html) for this module.
@@ -259,69 +296,6 @@ View the [change log](changelog.html) for this module.
 ## Feedback and Support
 
 Please direct all questions, feedback, and concerns to [info@appcelerator.com](mailto:info@appcelerator.com?subject=Android%20Admob%20Module).
-
-### Interstitial ads
-
-Starting from 4.4.0 this module now supports Interstitial ads for Android.
-
-Interstitial ads are full screen ads that are usually shown between natural steps of an application's interface flow.
-For instance doing different tasks in your application or between reading different articles.
-
-For best user experience Interstitial ads should be loaded prior showing the to the user. Interstitial ad instances can
-be used for showing one ad per loading, but they can be used multiple times. A good way of reusing an Interstitial ad is
-to show an ad, load a new after it has been closed one, and await for the proper time to show the recently loaded. 
-
-#### Properties
-
-##### adUnitId
-
-Id for this add. This property can be set in the creation dictionary or after creating the Interstitial ad instance.
-
-#### Methods
-
-##### setAdUnitId(String id)
-
-Sets the adUnitId property.
-
-##### getAdUnitId()
-
-Gets the adUnitId property.
-
-##### load()
-
-Loads an ad for this Interstitial ad instance.
-
-##### show()
-
-Shows an Interstitial ad if there is one successfully loaded. 
-
-#### Example:
-
-	// Create an Interstitial ad with a testing AdUnitId
-	var interstitialAd = Admob.createInterstitialAd({ adUnitId:"ca-app-pub-3940256099942544/1033173712" });
-
-	// Add all listeners for the add.
-	interstitialAd.addEventListener(Admob.AD_CLOSED, function () {
-	    Ti.API.info('Interstitial Ad closed!');
-	});
-	interstitialAd.addEventListener(Admob.AD_RECEIVED, function () {
-	    // When a new Interstitial ad is loaded, show it.
-	    Ti.API.info('Interstitial Ad loaded!');
-	    interstitialAd.show();
-	});
-	interstitialAd.addEventListener(Admob.AD_CLICKED, function () {
-	    Ti.API.info('Interstitial Ad clicked!');
-	});
-	interstitialAd.addEventListener(Admob.AD_NOT_RECEIVED, function (e) {
-	    Ti.API.info('Interstitial Ad not received! Error code = ' + e.errorCode);
-	});
-	interstitialAd.addEventListener(Admob.AD_OPENED, function () {
-	    Ti.API.info('Interstitial Ad opened!');
-	});
-	interstitialAd.addEventListener(Admob.AD_LEFT_APPLICATION, function () {
-	    Ti.API.info('Interstitial Ad left application!');
-	});
-	interstitialAd.load();
 
 ## Author
 

--- a/android/documentation/index.md
+++ b/android/documentation/index.md
@@ -46,108 +46,6 @@ The "Admob" variable is now a reference to the Module object.
 
 <https://developers.google.com/mobile-ads-sdk/>
 
-## Constants
-
-### Number `SUCCESS`
-Returned by `isGooglePlayServicesAvailable()` if the connection to Google Play Services was successful.
-
-### Number `SERVICE_MISSING`
-Returned by `isGooglePlayServicesAvailable()` if Google Play Services is missing on this device.
-
-### Number `SERVICE_VERSION_UPDATE_REQUIRED`
-Returned by `isGooglePlayServicesAvailable()` if the installed version of Google Play Services is out of date.
-
-### Number `SERVICE_DISABLED`
-Returned by `isGooglePlayServicesAvailable()` if the installed version of Google Play Services has been disabled on this device.
-
-### Number `SERVICE_INVALID`
-Returned by `isGooglePlayServicesAvailable()` if the version of the Google Play Services installed on this device is not authentic.
-
-### Number `CONSENT_STATUS_UNKNOWN`
-Returned by `consentStatus` if the consent status is unknown.
-
-### Number `CONSENT_STATUS_NON_PERSONALIZED`
-Returned by `consentStatus` if the consent status is not personalized.
-
-### Number `CONSENT_STATUS_PERSONALIZED`
-Returned by `consentStatus` if the consent status is personalized.
-
-### Number `DEBUG_GEOGRAPHY_DISABLED`
-Returned by `debugGeography` if geography debugging is disabled.
-
-### Number `DEBUG_GEOGRAPHY_EEA`
-Returned by `debugGeography` if geography appears as in EEA for debug devices.
-
-### Number `DEBUG_GEOGRAPHY_NOT_EEA`
-Returned by `debugGeography` if geography appears as not in EEA for debug devices.
-
-### `Admob.AD_RECEIVED`
-DEPRECATED since 5.0.0
-returns the constant for AD_RECEIVED -- for use in an event listener
-
-#### Example:
-
-	adMobView.addEventListener(Admob.AD_RECEIVED, function () {
-	    alert('ad was just received');
-	});
-
-### `Admob.AD_NOT_RECEIVED`
-DEPRECATED since 5.0.0
-returns whenever the ad was not successfully loaded. The callback contains the
-error code in its parameter under the key `errorCode`
-Error codes for Android can be checked here:
-https://developers.google.com/android/reference/com/google/android/gms/ads/AdRequest#ERROR_CODE_INTERNAL_ERROR
-
-#### Example:
-
-	adMobView.addEventListener(Admob.AD_NOT_RECEIVED, function (e) {
-	    alert('ad was not received. error code is ' + e.errorCode);
-	});
-
-### `Admob.AD_OPENED`
-DEPRECATED since 5.0.0
-returns the constant for AD_OPENED -- for use in an event listener
-
-#### Example:
-
-	adMobView.addEventListener(Admob.AD_OPENED, function () {
-	    alert('ad was just opened');
-	});
-
-### `Admob.AD_CLOSED`
-DEPRECATED since 5.0.0
-#### Example:
-
-	adMobView.addEventListener(Admob.AD_CLOSED, function () {
-	    alert('ad was just closed');
-	});
-
-### `Admob.AD_LEFT_APPLICATION`
-DEPRECATED since 5.0.0
-#### Example:
-
-	adMobView.addEventListener(Admob.AD_LEFT_APPLICATION, function () {
-	    alert('user just left the application through the ad');
-	});
-
-### Admob.AD_SIZE_BANNER
-
-### Admob.AD_SIZE_FLUID
-
-### Admob.AD_SIZE_FULL_BANNER
-
-### Admob.AD_SIZE_LARGE_BANNER
-
-### Admob.AD_SIZE_LEADERBOARD
-
-### Admob.AD_SIZE_MEDIUM_RECTANGLE
-
-### Admob.AD_SIZE_SEARCH
-
-### Admob.AD_SIZE_SMART_BANNER
-
-### Admob.AD_SIZE_WIDE_SKYSCRAPER
-
 ## Functions
 
 ### initialize(admobApplicationID)
@@ -162,7 +60,8 @@ Possible values include `SUCCESS`, `SERVICE_MISSING`, `SERVICE_VERSION_UPDATE_RE
 and `SERVICE_INVALID`.
 
 ### `createView(args)`
-DEPRECATED since 5.0.0
+
+DEPRECATED since 4.5.0. Use `createBannerView` instead.
 Returns a view with an ad initialized by default.
 
 #### Arguments
@@ -187,11 +86,26 @@ parameters[object]: a dictionary object of properties.
 	});
 
 ### `AdMobView.requestAd(args)`
-DEPRECATED since 5.0.0
+
+DEPRECATED since 4.5.0. Use `load()` instead.
 Calls for a new ad if needed. Pass optional `args` to configure extras.
 
 #### Example:
 
+```js
+    bannerView.load({
+        extras: {
+            adBackgroundColor:"FF8855", // optional
+            backgroundColorTop: "738000", //optional - Gradient background color at top
+            borderColor: "#000000", // optional - Border color
+            textColor: "#000000", // optional - Text color
+            urlColor: "#00FF00", // optional - URL color
+            linkColor: "#0000FF" //optional -  Link text color
+        }
+    });
+```
+
+Deprecated:
 ```js
 adMobView.requestAd({
     extras: {
@@ -201,7 +115,9 @@ adMobView.requestAd({
 ```
 
 ### `AdMobView.requestTestAd()`
-DEPRECATED since 5.0.0
+
+DEPRECATED since 4.5.0. Use `load()` with the `testDevices` property instead. More details about this can be found on this link:
+https://developers.google.com/admob/android/test-ads#enable_test_devices
 Calls for a test ad if needed. This works independently from the testing flag above.
 
 #### Example:
@@ -237,11 +153,13 @@ Callback to be triggered once the form completes.
 Resets consent information to default state and clears ad providers.
 
 ### `setTagForUnderAgeOfConsent(true|false)`
-DEPRECATED since 5.0.0
+
+DEPRECATED since 4.5.0. Use directly `isTaggedForUnderAgeOfConsent` instead.
 Sets whether the user is tagged for under age of consent.
 
 ### `isTaggedForUnderAgeOfConsent()` (Boolean)
-DEPRECATED since 5.0.0
+
+DEPRECATED since 4.5.0. Use directly `isTaggedForUnderAgeOfConsent` instead.
 Indicates whether the user is tagged for under age of consent.
 
 ## Properties
@@ -283,11 +201,148 @@ and a boolean value for the user's setting.
 		Ti.API.info('Ad tracking is limited: ' + data.isLimitAdTrackingEnabled);
 	});
 
-### Support the Facebook Audience Network adapter
+## Constants
+
+### Number `SUCCESS`
+Returned by `isGooglePlayServicesAvailable()` if the connection to Google Play Services was successful.
+
+### Number `SERVICE_MISSING`
+Returned by `isGooglePlayServicesAvailable()` if Google Play Services is missing on this device.
+
+### Number `SERVICE_VERSION_UPDATE_REQUIRED`
+Returned by `isGooglePlayServicesAvailable()` if the installed version of Google Play Services is out of date.
+
+### Number `SERVICE_DISABLED`
+Returned by `isGooglePlayServicesAvailable()` if the installed version of Google Play Services has been disabled on this device.
+
+### Number `SERVICE_INVALID`
+Returned by `isGooglePlayServicesAvailable()` if the version of the Google Play Services installed on this device is not authentic.
+
+### Number `CONSENT_STATUS_UNKNOWN`
+Returned by `consentStatus` if the consent status is unknown.
+
+### Number `CONSENT_STATUS_NON_PERSONALIZED`
+Returned by `consentStatus` if the consent status is not personalized.
+
+### Number `CONSENT_STATUS_PERSONALIZED`
+Returned by `consentStatus` if the consent status is personalized.
+
+### Number `DEBUG_GEOGRAPHY_DISABLED`
+Returned by `debugGeography` if geography debugging is disabled.
+
+### Number `DEBUG_GEOGRAPHY_EEA`
+Returned by `debugGeography` if geography appears as in EEA for debug devices.
+
+### Number `DEBUG_GEOGRAPHY_NOT_EEA`
+Returned by `debugGeography` if geography appears as not in EEA for debug devices.
+
+### `Admob.AD_RECEIVED`
+
+DEPRECATED since 4.5.0. Use `load` instead.
+returns the constant for AD_RECEIVED -- for use in an event listener
+
+#### Example:
+
+	adMobView.addEventListener('load', function () {
+	    alert('ad was just received');
+	});
+
+Deprecated:
+	adMobView.addEventListener(Admob.AD_RECEIVED, function () {
+	    alert('ad was just received');
+	});
+
+### `Admob.AD_NOT_RECEIVED`
+
+DEPRECATED since 4.5.0. Use `fail` instead.
+returns whenever the ad was not successfully loaded. The callback contains the
+error code in its parameter under the key `errorCode`
+Error codes for Android can be checked here:
+https://developers.google.com/android/reference/com/google/android/gms/ads/AdRequest#ERROR_CODE_INTERNAL_ERROR
+
+#### Example:
+
+	adMobView.addEventListener('fail', function (e) {
+	    alert('ad was not received. error code is ' + e.errorCode);
+	});
+
+Deprecated:
+	adMobView.addEventListener(Admob.AD_NOT_RECEIVED, function (e) {
+	    alert('ad was not received. error code is ' + e.errorCode);
+	});
+
+### `Admob.AD_OPENED`
+
+DEPRECATED since 4.5.0. Use `open` instead.
+returns the constant for AD_OPENED -- for use in an event listener
+
+#### Example:
+
+	adMobView.addEventListener('open', function () {
+	    alert('ad was just opened');
+	});
+
+Deprecated:
+	adMobView.addEventListener(Admob.AD_OPENED, function () {
+	    alert('ad was just opened');
+	});
+
+### `Admob.AD_CLOSED`
+
+DEPRECATED since 4.5.0. Use `close` instead.
+
+#### Example:
+
+	adMobView.addEventListener('closed', function () {
+	    alert('ad was just closed');
+	});
+
+Deprecated:
+	adMobView.addEventListener(Admob.AD_CLOSED, function () {
+	    alert('ad was just closed');
+	});
+
+### `Admob.AD_LEFT_APPLICATION`
+
+DEPRECATED since 4.5.0. Use `leftapp` instead. 
+
+#### Example:
+
+	adMobView.addEventListener('leftapp', function () {
+	    alert('user just left the application through the ad');
+	});
+
+Deprecated:
+	adMobView.addEventListener(Admob.AD_LEFT_APPLICATION, function () {
+	    alert('user just left the application through the ad');
+	});
+
+### Admob.AD_SIZE_BANNER
+
+### Admob.AD_SIZE_FLUID
+
+### Admob.AD_SIZE_FULL_BANNER
+
+### Admob.AD_SIZE_LARGE_BANNER
+
+### Admob.AD_SIZE_LEADERBOARD
+
+### Admob.AD_SIZE_MEDIUM_RECTANGLE
+
+### Admob.AD_SIZE_SEARCH
+
+### Admob.AD_SIZE_SMART_BANNER
+
+### Admob.AD_SIZE_WIDE_SKYSCRAPER
+
+## Support the Facebook Audience Network adapter
 
 Starting in 4.3.0 you can use the included Facebook Audience Network adapter to turn on the mediation in your AdMob account.
 Here you do not have to do anything 😙. You only need to configure mediation in your AdMob and Facebook accounts by 
 following the [official guide](https://developers.google.com/admob/android/mediation/facebook).
+
+WARNING! From version 4.5.0 the Facebook Audience Network adapter is deprecated. Once it is removed in a future release, it would depend
+on users to add it manually to the module when they need it.
 
 ## Module History
 

--- a/android/documentation/interstitialAd.md
+++ b/android/documentation/interstitialAd.md
@@ -1,0 +1,97 @@
+# Interstitial ads
+
+Starting from 4.4.0 this module now supports Interstitial ads for Android.
+
+Interstitial ads are full screen ads that are usually shown between natural steps of an application's interface flow.
+For instance doing different tasks in your application or between reading different articles.
+
+For best user experience Interstitial ads should be loaded prior showing the to the user. Interstitial ad instances can
+be used for showing one ad per loading, but they can be used multiple times. A good way of reusing an Interstitial ad is
+to show an ad, load a new after it has been closed one, and await for the proper time to show the recently loaded. 
+
+## Properties
+
+### adUnitId
+
+Id for this add. This property can be set in the creation dictionary or after creating the Interstitial ad instance.
+
+## Methods
+
+### setAdUnitId(String id)
+
+Sets the adUnitId property.
+
+### getAdUnitId()
+
+Gets the adUnitId property.
+
+### load([options])
+
+Loads an ad for this Interstitial ad instance.
+
+#### Parameters
+
+ options(optional) - dictionary containing options for customizing the load call.
+
+ | Name | Type | Description |
+| --- | --- | --- |
+| `options.keywords` | `Array<String>` | Keywords for targeting purposes. |
+| `options.extras` | `Object` | Extra parameters to pass to a specific ad network adapter. |
+| `options.contentUrl` | `Object` | Content URL for targeting purposes. |
+| `options.tagForChildDirectedTreatment` | `Boolean` | This option allows you to specify whether you would like your app to be treated as child-directed for purposes of the Children’s Online Privacy Protection Act (COPPA) - https//business.ftc.gov/privacy-and-security/childrens-privacy. |
+| `options.requestAgent` | `String` | Request agent string to identify the ad request's origin. |
+| `options.testDevices` | `Array<String>` | Test ads will be returned for devices with device IDs specified in this array. Use AdMob.SIMULATOR_ID to add the simulator. |
+
+### show()
+
+Shows an Interstitial ad if there is one successfully loaded. 
+
+## Events
+
+### load
+
+Fired when an ad finishes loading.
+
+### fail
+
+Fired when an ad request fails.
+
+### open
+
+Fired when an ad opens an overlay that covers the screen.
+
+### close
+
+Fired when the user is about to return to the app after tapping on an ad.
+
+### leftapp
+
+Fired when the user has left the app.
+
+## Example:
+
+	// Create an Interstitial ad with a testing AdUnitId
+	var interstitialAd = Admob.createInterstitialAd({ adUnitId:"ca-app-pub-3940256099942544/1033173712" });
+
+	// Add all listeners for the add.
+	interstitialAd.addEventListener(Admob.AD_CLOSED, function () {
+	    Ti.API.info('Interstitial Ad closed!');
+	});
+	interstitialAd.addEventListener(Admob.AD_RECEIVED, function () {
+	    // When a new Interstitial ad is loaded, show it.
+	    Ti.API.info('Interstitial Ad loaded!');
+	    interstitialAd.show();
+	});
+	interstitialAd.addEventListener(Admob.AD_CLICKED, function () {
+	    Ti.API.info('Interstitial Ad clicked!');
+	});
+	interstitialAd.addEventListener(Admob.AD_NOT_RECEIVED, function (e) {
+	    Ti.API.info('Interstitial Ad not received! Error code = ' + e.errorCode);
+	});
+	interstitialAd.addEventListener(Admob.AD_OPENED, function () {
+	    Ti.API.info('Interstitial Ad opened!');
+	});
+	interstitialAd.addEventListener(Admob.AD_LEFT_APPLICATION, function () {
+	    Ti.API.info('Interstitial Ad left application!');
+	});
+	interstitialAd.load();

--- a/android/manifest
+++ b/android/manifest
@@ -3,7 +3,7 @@
 # during compilation, packaging, distribution, etc.
 #
 
-version: 4.4.0
+version: 4.5.0
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86
 description: Titanium Admob module for Android

--- a/android/src/ti/admob/AdmobModule.java
+++ b/android/src/ti/admob/AdmobModule.java
@@ -13,6 +13,9 @@ import android.os.AsyncTask;
 import java.io.IOException;
 
 import com.google.android.gms.ads.identifier.AdvertisingIdClient;
+import com.google.android.gms.ads.AdRequest;
+import com.google.android.gms.ads.MobileAds;
+
 import com.google.android.gms.common.GooglePlayServicesUtil;
 import com.google.android.gms.common.GooglePlayServicesNotAvailableException;
 import com.google.android.gms.common.GooglePlayServicesRepairableException;
@@ -22,13 +25,17 @@ import org.appcelerator.kroll.KrollFunction;
 import org.appcelerator.kroll.KrollModule;
 import org.appcelerator.kroll.annotations.Kroll;
 import org.appcelerator.kroll.common.Log;
-import org.appcelerator.titanium.TiApplication;
-
 import org.appcelerator.kroll.KrollFunction;
 import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.KrollObject;
-import org.appcelerator.titanium.TiApplication;
 
+import org.appcelerator.titanium.TiApplication;
+import org.appcelerator.titanium.TiBlob;
+import org.appcelerator.titanium.io.TiBaseFile;
+import org.appcelerator.titanium.util.TiConvert;
+
+import java.io.IOException;
+import java.util.Map;
 import java.util.List;
 import java.util.Arrays;
 import java.util.ArrayList;
@@ -38,6 +45,7 @@ import java.net.MalformedURLException;
 import android.net.Uri;
 import android.content.Context;
 import android.app.Activity;
+import android.os.Bundle;
 
 import com.google.android.gms.common.GooglePlayServicesUtil;
 
@@ -48,6 +56,7 @@ import com.google.ads.consent.ConsentInfoUpdateListener;
 import com.google.ads.consent.ConsentStatus;
 import com.google.ads.consent.DebugGeography;
 import com.google.ads.consent.AdProvider;
+import com.google.ads.mediation.admob.AdMobAdapter;
 
 @Kroll.module(name = "Admob", id = "ti.admob")
 public class AdmobModule extends KrollModule
@@ -66,18 +75,24 @@ public class AdmobModule extends KrollModule
 	public static String PUBLISHER_ID;
 
 	// properties
+	public static String PROPERTY_AD_SIZE = "adSize";
 	public static String PROPERTY_AD_UNIT_ID = "adUnitId";
 	public static String PROPERTY_DEBUG_ENABLED = "debugEnabled";
-	public static String PROPERTY_TESTING = "testing";
-	public static String PROPERTY_PUBLISHER_ID = "publisherId";
 	public static String PROPERTY_COLOR_BG = "adBackgroundColor";
 	public static String PROPERTY_COLOR_BG_TOP = "backgroundTopColor";
 	public static String PROPERTY_COLOR_BORDER = "borderColor";
 	public static String PROPERTY_COLOR_TEXT = "textColor";
 	public static String PROPERTY_COLOR_LINK = "linkColor";
 	public static String PROPERTY_COLOR_URL = "urlColor";
-	public static String PROPERTY_COLOR_TEXT_DEPRECATED = "primaryTextColor";
-	public static String PROPERTY_COLOR_LINK_DEPRECATED = "secondaryTextColor";
+	public static String PROPERTY_IS_TAGGED_FOR_UNDER_AGE_OF_CONSENT = "isTaggedForUnderAgeOfConsent";
+
+
+	// new event constans
+	public static final String EVENT_AD_LOAD = "load";
+	public static final String EVENT_AD_FAIL = "fail";
+	public static final String EVENT_AD_CLOSED = "close";
+	public static final String EVENT_AD_OPENED = "open";
+	public static final String EVENT_AD_LEFT_APP = "leftapp";
 
 	public AdmobModule()
 	{
@@ -117,12 +132,42 @@ public class AdmobModule extends KrollModule
 	@Kroll.constant
 	public static final int CONSENT_STATUS_PERSONALIZED = 2;
 
+	// Debug geography constants
 	@Kroll.constant
 	public static final int DEBUG_GEOGRAPHY_DISABLED = 0;
 	@Kroll.constant
 	public static final int DEBUG_GEOGRAPHY_EEA = 1;
 	@Kroll.constant
 	public static final int DEBUG_GEOGRAPHY_NOT_EEA = 3;
+
+	// AdSize constants
+	@Kroll.constant
+	public static final int AD_SIZE_BANNER = 0;
+	@Kroll.constant
+	public static final int AD_SIZE_FLUID = 1;
+	@Kroll.constant
+	public static final int AD_SIZE_FULL_BANNER = 2;
+	@Kroll.constant
+	public static final int AD_SIZE_LARGE_BANNER = 3;
+	@Kroll.constant
+	public static final int AD_SIZE_LEADERBOARD = 4;
+	@Kroll.constant
+	public static final int AD_SIZE_MEDIUM_RECTANGLE = 5;
+	@Kroll.constant
+	public static final int AD_SIZE_SEARCH = 6;
+	@Kroll.constant
+	public static final int AD_SIZE_SMART_BANNER = 7;
+	@Kroll.constant
+	public static final int AD_SIZE_WIDE_SKYSCRAPER = 8;
+
+	@Kroll.constant
+	public static final String SIMULATOR_ID = AdRequest.DEVICE_ID_EMULATOR;
+
+	@Kroll.method
+	public void initialize(String appID)
+	{
+		MobileAds.initialize(TiApplication.getInstance(), appID);
+	}
 
 	@Kroll.method
 	public int isGooglePlayServicesAvailable()
@@ -352,8 +397,7 @@ public class AdmobModule extends KrollModule
 
 	// clang-format off
 	@Kroll.setProperty
-	@Kroll.method
-	public void setTagForUnderAgeOfConsent(boolean underAgeOfConsent)
+	public void setIsTaggedForUnderAgeOfConsent(boolean underAgeOfConsent)
 	// clang-format on
 	{
 		Context appContext = TiApplication.getInstance().getApplicationContext();
@@ -361,7 +405,16 @@ public class AdmobModule extends KrollModule
 	}
 
 	@Kroll.method
-	public boolean isTaggedForUnderAgeOfConsent()
+	public void setTagForUnderAgeOfConsent(boolean underAgeOfConsent)
+	{
+		Log.w(TAG, "setTagForUnderAgeOfConsent is deprecated. Use <setIsTaggedForUnderAgeOfConsent> property instead.");
+		Context appContext = TiApplication.getInstance().getApplicationContext();
+		ConsentInformation.getInstance(appContext).setTagForUnderAgeOfConsent(underAgeOfConsent);
+	}
+
+	@Kroll.getProperty
+	@Kroll.method
+	public boolean getIsTaggedForUnderAgeOfConsent()
 	{
 		Context appContext = TiApplication.getInstance().getApplicationContext();
 		return ConsentInformation.getInstance(appContext).isTaggedForUnderAgeOfConsent();
@@ -426,6 +479,118 @@ public class AdmobModule extends KrollModule
 		}
 
 		return result;
+	}
+
+	public static Bundle mapToBundle(Map<String, Object> map)
+	{
+		if (map == null) {
+			return new Bundle();
+		}
+
+		Bundle bundle = new Bundle(map.size());
+
+		for (String key : map.keySet()) {
+			Object val = map.get(key);
+			if (val == null) {
+				bundle.putString(key, null);
+			} else if (val instanceof TiBlob) {
+				bundle.putByteArray(key, ((TiBlob) val).getBytes());
+			} else if (val instanceof TiBaseFile) {
+				try {
+					bundle.putByteArray(key, ((TiBaseFile) val).read().getBytes());
+				} catch (IOException e) {
+					Log.e(TAG, "Unable to put '" + key + "' value into bundle: " + e.getLocalizedMessage(), e);
+				}
+			} else if (val instanceof AdmobSizeProxy) {
+				//
+			} else {
+				bundle.putString(key, TiConvert.toString(val));
+			}
+		}
+
+		return bundle;
+	}
+
+	public static AdRequest.Builder createRequestBuilderWithOptions(KrollDict options) {
+		AdRequest.Builder adRequestBuilder = new AdRequest.Builder();
+		if (options == null) {
+			return adRequestBuilder;
+		}
+		Bundle bundle = createAdRequestExtrasBundleFromDictionary(options.getKrollDict("extras"));
+		if (bundle.size() > 0) {
+			adRequestBuilder.addNetworkExtrasBundle(AdMobAdapter.class, bundle);
+		}
+		// Handle keywords
+		if (options.containsKeyAndNotNull("keywords")) {
+			String[] keywords = options.getStringArray("keywords");
+			for (int i = 0; i < keywords.length; i++) {
+				adRequestBuilder.addKeyword(keywords[i]);
+			}
+		}
+		// Handle contentURL
+		if (options.containsKeyAndNotNull("contentURL")) {
+			adRequestBuilder.setContentUrl(options.getString("contentURL"));
+		}
+		// Handle tagForChildDirectedTreatment
+		if (options.containsKeyAndNotNull("tagForChildDirectedTreatment")) {
+			adRequestBuilder.tagForChildDirectedTreatment(options.getBoolean("tagForChildDirectedTreatment"));
+		}
+		// Handle requestAgent
+		if (options.containsKeyAndNotNull("requestAgent")) {
+			adRequestBuilder.setRequestAgent(options.getString("requestAgent"));
+		}
+		// Handle testDevices
+		if (options.containsKeyAndNotNull("testDevices")) {
+			String [] testDevices = options.getStringArray("testDevices");
+			for (int i = 0; i < testDevices.length; i++) {
+				adRequestBuilder.addTestDevice(testDevices[i]);
+			}
+		}
+		return adRequestBuilder;
+	}
+
+	// create the adRequest extras bundle
+	private static Bundle createAdRequestExtrasBundleFromDictionary(KrollDict extrasDictionary)
+	{
+		Bundle bundle = new Bundle();
+		if (extrasDictionary.containsKey(AdmobModule.PROPERTY_COLOR_BG)) {
+			bundle.putString("color_bg", convertColorProp(extrasDictionary.getString(AdmobModule.PROPERTY_COLOR_BG)));
+		}
+		if (extrasDictionary.containsKey(AdmobModule.PROPERTY_COLOR_BG_TOP)) {
+			bundle.putString("color_bg_top", convertColorProp(extrasDictionary.getString(AdmobModule.PROPERTY_COLOR_BG_TOP)));
+		}
+		if (extrasDictionary.containsKey(AdmobModule.PROPERTY_COLOR_BORDER)) {
+			bundle.putString("color_border", convertColorProp(extrasDictionary.getString(AdmobModule.PROPERTY_COLOR_BORDER)));
+		}
+		if (extrasDictionary.containsKey(AdmobModule.PROPERTY_COLOR_TEXT)) {
+			bundle.putString("color_text", convertColorProp(extrasDictionary.getString(AdmobModule.PROPERTY_COLOR_TEXT)));
+		}
+		if (extrasDictionary.containsKey(AdmobModule.PROPERTY_COLOR_LINK)) {
+			bundle.putString("color_link", convertColorProp(extrasDictionary.getString(AdmobModule.PROPERTY_COLOR_LINK)));
+		}
+		if (extrasDictionary.containsKey(AdmobModule.PROPERTY_COLOR_URL)) {
+			bundle.putString("color_url", convertColorProp(extrasDictionary.getString(AdmobModule.PROPERTY_COLOR_URL)));
+		}
+		return bundle;
+	}
+
+	// modifies the color prop -- removes # and changes constants into hex values
+	public static String convertColorProp(String color)
+	{
+		color = color.replace("#", "");
+		if (color.equals("white"))
+			color = "FFFFFF";
+		if (color.equals("red"))
+			color = "FF0000";
+		if (color.equals("blue"))
+			color = "0000FF";
+		if (color.equals("green"))
+			color = "008000";
+		if (color.equals("yellow"))
+			color = "FFFF00";
+		if (color.equals("black"))
+			color = "000000";
+		return color;
 	}
 
 }

--- a/android/src/ti/admob/AdmobModule.java
+++ b/android/src/ti/admob/AdmobModule.java
@@ -172,6 +172,7 @@ public class AdmobModule extends KrollModule
 	@Kroll.method
 	public int isGooglePlayServicesAvailable()
 	{
+		Log.w(TAG, "isGooglePlayServices in ti.admob is deprecated. Use the same method from ti.playservices instead.");
 		return GooglePlayServicesUtil.isGooglePlayServicesAvailable(TiApplication.getAppRootOrCurrentActivity());
 	}
 

--- a/android/src/ti/admob/AdmobSizeEnum.java
+++ b/android/src/ti/admob/AdmobSizeEnum.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2011 by Studio Classics. All Rights Reserved.
+ * Copyright (c) 2017-present by Axway Appcelerator. All Rights Reserved.
+ * Author: Brian Kurzius, Axway Appcelerator
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+package ti.admob;
+
+import com.google.android.gms.ads.AdSize;
+
+public enum AdmobSizeEnum {
+
+	BANNER(AdmobModule.AD_SIZE_BANNER, AdSize.BANNER),
+	FLUID(AdmobModule.AD_SIZE_FLUID, AdSize.FLUID),
+	FULL_BANNER(AdmobModule.AD_SIZE_FULL_BANNER, AdSize.FULL_BANNER),
+	LARGE_BANNER(AdmobModule.AD_SIZE_LARGE_BANNER, AdSize.LARGE_BANNER),
+	LEADERBOARD(AdmobModule.AD_SIZE_LEADERBOARD, AdSize.LEADERBOARD),
+	MEDIUM_RECTANGLE(AdmobModule.AD_SIZE_MEDIUM_RECTANGLE, AdSize.MEDIUM_RECTANGLE),
+	SEARCH(AdmobModule.AD_SIZE_SEARCH, AdSize.SEARCH),
+	SMART_BANNER(AdmobModule.AD_SIZE_SMART_BANNER, AdSize.SMART_BANNER),
+	WIDE_SKYSCRAPER(AdmobModule.AD_SIZE_WIDE_SKYSCRAPER, AdSize.WIDE_SKYSCRAPER);
+
+	private final AdmobSizeProxy admobSizeProxy;
+	private final int adSizeConstantValue;
+
+	private AdmobSizeEnum(int intValue, AdSize adSizeValue) {
+		this.admobSizeProxy = new AdmobSizeProxy(adSizeValue);
+		this.adSizeConstantValue = intValue;
+	}
+
+	public static AdmobSizeEnum fromModuleConst(int value)
+	{
+		for (AdmobSizeEnum nextObject : AdmobSizeEnum.values()) {
+			if ((nextObject != null) && (nextObject.adSizeConstantValue == value)) {
+				return nextObject;
+			}
+		}
+		return null;
+	}
+
+	public AdmobSizeProxy getAdmobSizeProxy() {
+		return this.admobSizeProxy;
+	}
+
+}

--- a/android/src/ti/admob/AdmobSizeProxy.java
+++ b/android/src/ti/admob/AdmobSizeProxy.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2011 by Studio Classics. All Rights Reserved.
+ * Copyright (c) 2017-present by Axway Appcelerator. All Rights Reserved.
+ * Author: Brian Kurzius, Axway Appcelerator
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+package ti.admob;
+
+import org.appcelerator.kroll.annotations.Kroll;
+import org.appcelerator.kroll.KrollProxy;
+import org.appcelerator.kroll.common.Log;
+
+import com.google.android.gms.ads.AdSize;
+
+@Kroll.proxy
+public class AdmobSizeProxy extends KrollProxy
+{
+
+	private AdSize adSize;
+
+	private static final String TAG = "AdmobSizeProxy";
+
+	public AdmobSizeProxy(AdSize adSizeValue) {
+		super();
+		this.adSize = adSizeValue;
+	}
+
+	public AdSize getAdSize() {
+		return this.adSize;
+	}
+
+	@Kroll.method
+	public int getWidth() {
+		if (this.adSize != null) {
+			return adSize.getWidth();
+		}
+		return -1;
+	}
+
+	@Kroll.method
+	public int getHeight() {
+		if (this.adSize != null) {
+			return adSize.getHeight();
+		}
+		return -1;
+	}
+
+}

--- a/android/src/ti/admob/BannerViewProxy.java
+++ b/android/src/ti/admob/BannerViewProxy.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2011 by Studio Classics. All Rights Reserved.
+ * Copyright (c) 2017-present by Axway Appcelerator. All Rights Reserved.
+ * Author: Brian Kurzius, Axway Appcelerator
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+package ti.admob;
+
+import org.appcelerator.kroll.annotations.Kroll;
+import org.appcelerator.kroll.common.Log;
+import org.appcelerator.kroll.KrollDict;
+import org.appcelerator.kroll.annotations.Kroll;
+
+import org.appcelerator.titanium.proxy.TiViewProxy;
+import org.appcelerator.titanium.TiLifecycle.OnLifecycleEvent;
+import org.appcelerator.titanium.proxy.TiViewProxy;
+import org.appcelerator.titanium.TiBaseActivity;
+import org.appcelerator.titanium.view.TiUIView;
+
+import android.app.Activity;
+
+@Kroll.proxy(creatableInModule = AdmobModule.class)
+public class BannerViewProxy extends TiViewProxy implements OnLifecycleEvent
+{
+	private AdmobView adMob;
+	protected static final String TAG = "BannerViewProxy";
+
+	public BannerViewProxy()
+	{
+		super();
+	}
+
+	@Override
+	protected KrollDict getLangConversionTable()
+	{
+		KrollDict table = new KrollDict();
+		table.put("title", "titleid");
+		return table;
+	}
+
+	@Override
+	public TiUIView createView(Activity activity)
+	{
+		adMob = new AdmobView(this);
+		((TiBaseActivity) activity).addOnLifecycleEventListener(this);
+		return adMob;
+	}
+
+	@Kroll.method
+	public void requestAd(@Kroll.argument(optional = true) KrollDict parameters)
+	{
+		adMob.requestAd(parameters);
+		Log.w(TAG, "requestAd() had been deprecated. Use load() instead.");
+	}
+
+	@Kroll.method
+	public void requestTestAd()
+	{
+		adMob.requestTestAd();
+		Log.w(TAG, "requestAd() had been deprecated. Use load() with 'debugIdentifiers' property instead.");
+	}
+
+	@Kroll.method
+	public void load(@Kroll.argument(optional = true) KrollDict options) {
+		// Load ad with options...
+		adMob.nativeLoadAd(options);
+	}
+
+	@Override
+	public void onDestroy(Activity activity)
+	{
+		adMob.destroy();
+	}
+
+	@Override
+	public void onPause(Activity activity)
+	{
+		adMob.pause();
+	}
+
+	@Override
+	public void onResume(Activity activity)
+	{
+		adMob.resume();
+	}
+
+	@Override
+	public void onStart(Activity activity)
+	{
+	}
+
+	@Override
+	public void onStop(Activity activity)
+	{
+	}
+}

--- a/android/src/ti/admob/BannerViewProxy.java
+++ b/android/src/ti/admob/BannerViewProxy.java
@@ -51,14 +51,14 @@ public class BannerViewProxy extends TiViewProxy implements OnLifecycleEvent
 	public void requestAd(@Kroll.argument(optional = true) KrollDict parameters)
 	{
 		adMob.requestAd(parameters);
-		Log.w(TAG, "requestAd() had been deprecated. Use load() instead.");
+		Log.w(TAG, "requestAd() has been deprecated. Use load() instead.");
 	}
 
 	@Kroll.method
 	public void requestTestAd()
 	{
 		adMob.requestTestAd();
-		Log.w(TAG, "requestAd() had been deprecated. Use load() with 'debugIdentifiers' property instead.");
+		Log.w(TAG, "requestAd() has been deprecated. Use load() with 'debugIdentifiers' property instead.");
 	}
 
 	@Kroll.method

--- a/android/src/ti/admob/CommonAdListener.java
+++ b/android/src/ti/admob/CommonAdListener.java
@@ -15,6 +15,8 @@ import org.appcelerator.kroll.common.Log;
 
 public class CommonAdListener extends AdListener {
 
+	private final static String TAG = "AdEventListener";
+
 	private KrollProxy sourceProxy;
 	private String sourceTag;
 
@@ -26,7 +28,9 @@ public class CommonAdListener extends AdListener {
 	@Override
 	public void onAdLoaded() {
 		Log.d(this.sourceTag, "onAdLoaded()");
+		warnForDeprecatedConstant(AdmobModule.AD_RECEIVED, AdmobModule.EVENT_AD_LOAD);
 		this.sourceProxy.fireEvent(AdmobModule.AD_RECEIVED, new KrollDict());
+		this.sourceProxy.fireEvent(AdmobModule.EVENT_AD_LOAD, new KrollDict());
 	}
 
 	@Override
@@ -36,24 +40,36 @@ public class CommonAdListener extends AdListener {
 		Log.d(this.sourceTag, "onAdFailedToLoad(): " + errorCode);
 		KrollDict eventData = new KrollDict();
 		eventData.put("errorCode", String.valueOf(errorCode));
+		warnForDeprecatedConstant(AdmobModule.AD_NOT_RECEIVED, AdmobModule.EVENT_AD_FAIL);
 		this.sourceProxy.fireEvent(AdmobModule.AD_NOT_RECEIVED, eventData);
+		this.sourceProxy.fireEvent(AdmobModule.EVENT_AD_FAIL, eventData);
 	}
 
 	@Override
 	public void onAdClosed() {
 		super.onAdClosed();
+		warnForDeprecatedConstant(AdmobModule.AD_CLOSED, AdmobModule.EVENT_AD_CLOSED);
 		this.sourceProxy.fireEvent(AdmobModule.AD_CLOSED, new KrollDict());
+		this.sourceProxy.fireEvent(AdmobModule.EVENT_AD_CLOSED, new KrollDict());
 	}
 
 	@Override
 	public void onAdOpened() {
 		super.onAdOpened();
+		warnForDeprecatedConstant(AdmobModule.AD_OPENED, AdmobModule.EVENT_AD_OPENED);
 		this.sourceProxy.fireEvent(AdmobModule.AD_OPENED, new KrollDict());
+		this.sourceProxy.fireEvent(AdmobModule.EVENT_AD_OPENED, new KrollDict());
 	}
 
 	@Override
 	public void onAdLeftApplication() {
 		super.onAdLeftApplication();
+		warnForDeprecatedConstant(AdmobModule.AD_LEFT_APPLICATION, AdmobModule.EVENT_AD_LEFT_APP);
 		this.sourceProxy.fireEvent(AdmobModule.AD_LEFT_APPLICATION, new KrollDict());
+		this.sourceProxy.fireEvent(AdmobModule.EVENT_AD_LEFT_APP, new KrollDict());
+	}
+
+	private void warnForDeprecatedConstant(String deprecatedConstant, String newConstant) {
+		Log.w(TAG, "\"" + deprecatedConstant + "\" is deprecated. Use \"" + newConstant + "\" instead.");
 	}
 }

--- a/android/src/ti/admob/InterstitialAdProxy.java
+++ b/android/src/ti/admob/InterstitialAdProxy.java
@@ -7,6 +7,8 @@
 
 package ti.admob;
 
+import android.os.Bundle;
+
 import com.google.android.gms.ads.AdRequest;
 import com.google.android.gms.ads.InterstitialAd;
 
@@ -14,6 +16,8 @@ import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.KrollProxy;
 import org.appcelerator.kroll.annotations.Kroll;
 import org.appcelerator.kroll.common.Log;
+
+import com.google.ads.mediation.admob.AdMobAdapter;
 
 @Kroll.proxy(creatableInModule = AdmobModule.class)
 public class InterstitialAdProxy extends KrollProxy {
@@ -56,9 +60,10 @@ public class InterstitialAdProxy extends KrollProxy {
 	}
 
 	@Kroll.method
-	public void load()
+	public void load(@Kroll.argument(optional = true) KrollDict options)
 	{
-		this.interstitialAd.loadAd(new AdRequest.Builder().build());
+		AdRequest.Builder adRequestBuilder = AdmobModule.createRequestBuilderWithOptions(options);
+		interstitialAd.loadAd(adRequestBuilder.build());
 	}
 
 	@Kroll.method

--- a/android/src/ti/admob/ViewProxy.java
+++ b/android/src/ti/admob/ViewProxy.java
@@ -7,92 +7,22 @@
  */
 package ti.admob;
 
-import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.annotations.Kroll;
-import org.appcelerator.titanium.TiLifecycle.OnLifecycleEvent;
-import org.appcelerator.titanium.proxy.TiViewProxy;
-import org.appcelerator.titanium.TiBaseActivity;
 import org.appcelerator.kroll.common.Log;
-import org.appcelerator.titanium.view.TiUIView;
 
-import android.app.Activity;
-
+/**
+ * This class is left for backwards compatibility until
+ * the deprecated createView() method for BannerView ad
+ * is removed from the module. Users should use createBannerView()
+*/
 @Kroll.proxy(creatableInModule = AdmobModule.class)
-public class ViewProxy extends TiViewProxy implements OnLifecycleEvent
+public class ViewProxy extends BannerViewProxy
 {
-	private View adMob;
-	private static final String TAG = "AdMobViewProxy";
 
-	public ViewProxy()
-	{
-		super();
+	protected static final String TAG = "AdMobViewProxy";
+
+	public ViewProxy() {
+		Log.w(TAG, "ViewProxy has been deprecated. Use createBannerView instead.");
 	}
 
-	@Kroll.method @Kroll.setProperty
-	public void setPublisherId(String id) {
-		Log.w(TAG, AdmobModule.PROPERTY_PUBLISHER_ID + " has been deprecated. Please use adUnitId.");
-	}
-
-	@Kroll.method @Kroll.setProperty
-	public void setTesting(Boolean test) {
-		Log.w(TAG, AdmobModule.PROPERTY_TESTING + " has been deprecated. Please use debugEnabled.");
-	}
-
-	@Override
-	protected KrollDict getLangConversionTable()
-	{
-		KrollDict table = new KrollDict();
-		table.put("title", "titleid");
-		return table;
-	}
-
-	@Override
-	public TiUIView createView(Activity activity)
-	{
-		adMob = new View(this);
-		((TiBaseActivity) activity).addOnLifecycleEventListener(this);
-		return adMob;
-	}
-
-	@Kroll.method
-	public void requestAd(@Kroll.argument(optional = true) KrollDict parameters)
-	{
-		Log.d(TAG, "requestAd()");
-		adMob.requestAd(parameters);
-	}
-
-	@Kroll.method
-	public void requestTestAd()
-	{
-		Log.d(TAG, "requestTestAd(): ");
-		adMob.requestTestAd();
-	}
-
-	@Override
-	public void onDestroy(Activity activity)
-	{
-		adMob.destroy();
-	}
-
-	@Override
-	public void onPause(Activity activity)
-	{
-		adMob.pause();
-	}
-
-	@Override
-	public void onResume(Activity activity)
-	{
-		adMob.resume();
-	}
-
-	@Override
-	public void onStart(Activity activity)
-	{
-	}
-
-	@Override
-	public void onStop(Activity activity)
-	{
-	}
 }


### PR DESCRIPTION
**JIRA**: https://jira.appcelerator.org/browse/MOD-2497

**~~This PR needs ti.playservices version 16.1.3 to work.~~**
**This PR needs ti.playservices version 16.1.4 to work.**
https://github.com/appcelerator-modules/ti.playservices/releases/tag/16.1.4

Deprecate outdated APIs. Remove previously deprecated APIs. Add AdmobSizeProxy. Introduce BannerView. Introduce the `load([options])` method for both BannerView and Interstitial ads. Slight update of the docs.

@janvennemann Two things that I think need mentioning. On Android we do support only String and number type of constants, so I was not able to use AdmobSizeProxy as a type for the size constant - I have matched them to integers through an enum. We do not support that for our core SDK too and it will require a proxy binding template change (if possible at all). And the second one - I wanted to keep full backwards compatibility with the previous version, so maybe we add a deprecation warning for the Facebook mediation libs for now and remove them in the next major version?   