### PR TITLE
Some initialization fixes to bring the Proxy on par with iOS side.

### DIFF
--- a/android/src/ti/admob/AdmobModule.java
+++ b/android/src/ti/admob/AdmobModule.java
@@ -554,6 +554,10 @@ public class AdmobModule extends KrollModule
 	private static Bundle createAdRequestExtrasBundleFromDictionary(KrollDict extrasDictionary)
 	{
 		Bundle bundle = new Bundle();
+		// There is no "extras" key in the options dictionary.
+		if (extrasDictionary == null) {
+			return bundle;
+		}
 		if (extrasDictionary.containsKey(AdmobModule.PROPERTY_COLOR_BG)) {
 			bundle.putString("color_bg", convertColorProp(extrasDictionary.getString(AdmobModule.PROPERTY_COLOR_BG)));
 		}

--- a/android/src/ti/admob/AdmobView.java
+++ b/android/src/ti/admob/AdmobView.java
@@ -24,7 +24,7 @@ import com.google.ads.mediation.admob.AdMobAdapter;
 public class AdmobView extends TiUIView
 {
 	private static final String TAG = "AdMobView";
-	private AdView adView;
+	private final AdView adView;
 
 	AdmobSizeProxy prop_adSize = AdmobSizeEnum.BANNER.getAdmobSizeProxy();
 	String prop_adUnitId;
@@ -45,13 +45,12 @@ public class AdmobView extends TiUIView
 	public AdmobView(final TiViewProxy proxy)
 	{
 		super(proxy);
+		adView = new AdView(proxy.getActivity());
 	}
 
 	private void createAdView()
 	{
 		Log.d(TAG, "createAdView()");
-
-		adView = new AdView(proxy.getActivity());
 
 		adView.setAdUnitId(prop_adUnitId);
 		adView.setAdSize(prop_adSize.getAdSize());
@@ -62,7 +61,6 @@ public class AdmobView extends TiUIView
 		// Add the AdView to your view hierarchy.
 		// The view will have no size until the ad is loaded.
 		setNativeView(adView);
-		loadAd(prop_debugEnabled, null);
 	}
 
 	//Deprecated in 5.0.0. Should be remove in 6.0.0

--- a/android/src/ti/admob/BannerViewProxy.java
+++ b/android/src/ti/admob/BannerViewProxy.java
@@ -29,6 +29,7 @@ public class BannerViewProxy extends TiViewProxy implements OnLifecycleEvent
 	public BannerViewProxy()
 	{
 		super();
+		this.adMob = new AdmobView(this);
 	}
 
 	@Override
@@ -42,47 +43,46 @@ public class BannerViewProxy extends TiViewProxy implements OnLifecycleEvent
 	@Override
 	public TiUIView createView(Activity activity)
 	{
-		adMob = new AdmobView(this);
 		((TiBaseActivity) activity).addOnLifecycleEventListener(this);
-		return adMob;
+		return this.adMob;
 	}
 
 	@Kroll.method
 	public void requestAd(@Kroll.argument(optional = true) KrollDict parameters)
 	{
-		adMob.requestAd(parameters);
+		this.adMob.requestAd(parameters);
 		Log.w(TAG, "requestAd() has been deprecated. Use load() instead.");
 	}
 
 	@Kroll.method
 	public void requestTestAd()
 	{
-		adMob.requestTestAd();
+		this.adMob.requestTestAd();
 		Log.w(TAG, "requestAd() has been deprecated. Use load() with 'debugIdentifiers' property instead.");
 	}
 
 	@Kroll.method
 	public void load(@Kroll.argument(optional = true) KrollDict options) {
 		// Load ad with options...
-		adMob.nativeLoadAd(options);
+		this.adMob.nativeLoadAd(options);
 	}
 
 	@Override
 	public void onDestroy(Activity activity)
 	{
-		adMob.destroy();
+		this.adMob.destroy();
 	}
 
 	@Override
 	public void onPause(Activity activity)
 	{
-		adMob.pause();
+		this.adMob.pause();
 	}
 
 	@Override
 	public void onResume(Activity activity)
 	{
-		adMob.resume();
+		this.adMob.resume();
 	}
 
 	@Override


### PR DESCRIPTION
Proxy's properties are processed only after the AdView has been added to the screen and this is a disparity with how things work on iOS side. This PR will move dealing with creation dictionaries when the proxy has been created.

Also any other faulty behavior, caused by merging the refactoring into master, for the Android side will be addressed in this PR. 